### PR TITLE
Document and handle expiring credentials

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -8,7 +8,7 @@ This is the client library part of Cargoplane.
 
 ### connect 
 
-Connects/reconnects to Cargoplane Cloud.
+Connects/reconnects to Cargoplane Cloud with the given credentials.
 
 ```
 connect(credential: CargoplaneCredential): void
@@ -16,24 +16,39 @@ connect(credential: CargoplaneCredential): void
 
 The `credential` must be retrieved from the companion Lambda in the cloud package.
 
+The `expiration` field in `CargoplaneCredential` provides the expiration ISO date-time of the credentials.
+You must obtain new credentials and reconnect prior to expiration in order to remain connected. Subscriptions
+are automatically re-applied upon reconnect. The expiration period is normally one hour, but it is best to use
+this value rather than assume one hour.
+
+### disconnect 
+
+Disconnect and clear all subscriptions. (Ex: upon user logout)
+
+```
+disconnect(): void 
+```
+### isOnline
+
+Is the service currently connected to the cloud?
+If network access is lost, it will automatically attempt to reconnect when network access is
+restored provided that the credentials have not expired.
+
+    isOnline(): boolean
 
 ### observe
 
-Subscribes to a topic and create an observable.
+Obtain an RxJs Observable of a topic.
+This call will automatically subscribe to the topic if this is the first request to observe it.
 
 ```
 observe(topic: string): Observable<any>
 ```
 
 ### publish 
+
+Publish a message to a topic.
+
 ```
 publish(topic: string, message?: any): void 
-```
-
-### disconnect 
-
-Disconnects disconnects to Cargoplane Cloud.
-
-```
-disconnect(): void 
 ```

--- a/client/lib/cargoplane-client.ts
+++ b/client/lib/cargoplane-client.ts
@@ -5,22 +5,32 @@ import * as awsIot from 'aws-iot-device-sdk';
  * Approved credentials for use by this client instance.
  */
 export interface CargoplaneCredential {
-    iotEndpoint: string,
-    region: string,
-    accessKey: string,
-    secretKey: string,
-    sessionToken: string
+    iotEndpoint: string;
+    region: string;
+    accessKey: string;
+    secretKey: string;
+    sessionToken: string;
+    /** ISO-8601 date-time of when the credentials expire - normally one hour after issuing */
+    expiration: string;
+
 }
 
 /** Message queued for publishing */
 interface QueuedMessage {
-    topic: string,
-    message?: any
+    topic: string;
+    message?: any;
 }
 
 /**
  * Web browser-side API for Cargoplane.
  * Must use as a singleton.
+ *
+ * Credentials must be obtained via CargoplaneCloud#createCredentials() via code running
+ * in AWS. Note that the credentials include an expiration date-time.
+ * You must obtain new credentials and reconnect prior to expiration in order to remain
+ * connected. Subscriptions are automatically re-applied upon reconnect. The expiration
+ * period is normally one hour, but it is best to use this value rather than assume one
+ * hour.
  */
 export class CargoplaneClient {
 
@@ -39,7 +49,9 @@ export class CargoplaneClient {
     }
 
     /**
-     * Connect to cloud Cargoplane with given flight credentials.
+     * Connect to cloud Cargoplane with given credentials.
+     *
+     * @param credential as received by calling a CargoplaneCloud#createCredentials()
      */
     connect(credential: CargoplaneCredential): void {
         console.debug("Cargoplane connecting");
@@ -100,7 +112,7 @@ export class CargoplaneClient {
     }
 
     /**
-     * Disconnect all subscriptions (upon user logout)
+     * Disconnect and clear all subscriptions. (Ex: upon user logout)
      */
     disconnect(): void {
         this.typeSubjects.forEach(subject => {
@@ -116,7 +128,7 @@ export class CargoplaneClient {
 
     /**
      * Obtain an RxJs Observable of a topic.
-     * The function will automatically subscribe to the IoT topic if this is the first request to observe it.
+     * The call will automatically subscribe to the topic if this is the first request to observe it.
      *
      * @param topic
      * @returns Observable that will receive events when message are received on the type.

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cargoplane/client",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cargoplane/client",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Web client library for publishing messages to and subscribing to to messages via AWS IoT.",
   "keywords": [
     "aws",

--- a/cloud/lib/cargoplane-cloud.ts
+++ b/cloud/lib/cargoplane-cloud.ts
@@ -9,29 +9,31 @@ const sts = new AWS.STS();
  */
 export interface CargoplaneCredentialRequest {
     /** AWS Region to use. If not given, AWS_REGION environment variable is used */
-    region?: string,
+    region?: string;
     /** Base IAM role name for the credentials */
-    roleName: string,
+    roleName: string;
     /**
      * Optional prefix to use on client name to avoid conflict
      * with other applications in the AWS account
      */
-    sessionNamePrefix?: string,
+    sessionNamePrefix?: string;
     /** Full topic names credentials are to grant publishing to */
-    pubTopics: string[],
+    pubTopics: string[];
     /** Full topic names credentials are to grant subscription to */
-    subTopics: string[]
+    subTopics: string[];
 }
 
 /**
  * Approved credentials for use by a client instance.
  */
 export interface CargoplaneCredential {
-    iotEndpoint: string,
-    region: string,
-    accessKey: string,
-    secretKey: string,
-    sessionToken: string
+    iotEndpoint: string;
+    region: string;
+    accessKey: string;
+    secretKey: string;
+    sessionToken: string;
+    /** ISO-8601 date-time of when the credentials expire - normally one hour after issuing */
+    expiration: string;
 }
 
 /**
@@ -67,7 +69,8 @@ export class CargoplaneCloud {
             region: awsRegion,
             accessKey: roleCredentials.AccessKeyId,
             secretKey: roleCredentials.SecretAccessKey,
-            sessionToken: roleCredentials.SessionToken
+            sessionToken: roleCredentials.SessionToken,
+            expiration: roleCredentials.Expiration.toISOString()
         };
     };
 

--- a/cloud/package-lock.json
+++ b/cloud/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cargoplane/cloud",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cloud/package.json
+++ b/cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cargoplane/cloud",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "AWS cloud-side library for publishing messages to and subscribing to to messages via AWS IoT.",
   "keywords": [
     "aws",

--- a/demo/client/ng-cargoplane-demo/package-lock.json
+++ b/demo/client/ng-cargoplane-demo/package-lock.json
@@ -651,9 +651,9 @@
       }
     },
     "@cargoplane/client": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@cargoplane/client/-/client-0.0.2.tgz",
-      "integrity": "sha512-7OltD9MySd2wF2sQDiE8bQ43ZxIBzX7Xiv1GZVAyWgasDinMbCU76m3PfWfHEayF4THNhfFfL1epoKJScyBk0Q=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@cargoplane/client/-/client-0.0.3.tgz",
+      "integrity": "sha512-d/JAnjsv6TB9RZz1laS9CE+PdywJ3feUWrnlheZlyvQCc8U+rf7HOgYEymEXcBOTCVbi3IyGFjLT9Zfhy6pXAA=="
     },
     "@ngtools/webpack": {
       "version": "7.3.9",

--- a/demo/client/react-cargoplane-demo/package-lock.json
+++ b/demo/client/react-cargoplane-demo/package-lock.json
@@ -940,9 +940,9 @@
       }
     },
     "@cargoplane/client": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@cargoplane/client/-/client-0.0.1.tgz",
-      "integrity": "sha512-nP9k8S+Hnjvn+1V6uZ1++WBl7Fc2UIbhyaFVIRd1Giph08WTF8rZDS2tXqBZaNWFHV9IEpli74duVEix7NlH3g=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@cargoplane/client/-/client-0.0.3.tgz",
+      "integrity": "sha512-d/JAnjsv6TB9RZz1laS9CE+PdywJ3feUWrnlheZlyvQCc8U+rf7HOgYEymEXcBOTCVbi3IyGFjLT9Zfhy6pXAA=="
     },
     "@cnakazawa/watch": {
       "version": "1.0.3",

--- a/demo/cloud/package-lock.json
+++ b/demo/cloud/package-lock.json
@@ -4,9 +4,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@cargoplane/cloud": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@cargoplane/cloud/-/cloud-0.0.1.tgz",
-      "integrity": "sha512-7f39A6w2ai2FznzSS5NOtkMoDdS1rHS+nJVk9Uo1PLlkUQGL7YIPfNM4BnLVh8WcKQozxjI3ICOEWJNHCmxGGA==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@cargoplane/cloud/-/cloud-0.0.2.tgz",
+      "integrity": "sha512-FGI5SDzqohqqgcCjGKxCg5vGwVnH7a5roQ5O1JvwXuxOdVcTS1qxRkUzqxnaDWdF0+EwFdg0fVa+kDNYngtarA==",
       "requires": {
         "source-map-support": "^0.5.9"
       }


### PR DESCRIPTION
- Cargoplane credentials are only good for a limited time!
- Updated client documentation to reflect this, and more API documentation in general.
- Added 'expiration' field to credentials.
- Updated both client apps to renew credentials before they expire.